### PR TITLE
Release for v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [v0.1.4](https://github.com/michimani/vscode-clangd-include-cleaner/compare/v0.1.3...v0.1.4) - 2026-04-17
+- chore: add some badges by @michimani in https://github.com/michimani/vscode-clangd-include-cleaner/pull/19
+- chore(deps): update node.js to v24.14.1 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/21
+- chore(deps): update dependency @biomejs/biome to v2.4.9 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/22
+- chore(deps): update dependency @biomejs/biome to v2.4.10 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/23
+- chore(deps): update dependency @types/node to v24.12.2 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/24
+- chore(deps): update songmu/tagpr digest to e7ae290 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/25
+- chore(deps): update songmu/tagpr digest to 9d0f650 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/26
+- chore(deps): update dependency @types/vscode to v1.115.0 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/27
+- chore(deps): update dependency @biomejs/biome to v2.4.11 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/28
+- chore(deps): update songmu/tagpr digest to 84850af by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/29
+- chore(deps): update dependency @biomejs/biome to v2.4.12 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/30
+- chore(deps): update dependency @types/vscode to v1.116.0 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/31
+- chore(deps): update songmu/tagpr digest to 9bbb945 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/33
+- chore(deps): update dependency typescript to v6.0.3 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/34
+- chore(deps): update node.js to v24.15.0 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/32
+
 ## [v0.1.3](https://github.com/michimani/vscode-clangd-include-cleaner/compare/v0.1.2...v0.1.3) - 2026-03-24
 - chore(deps): update dependency @biomejs/biome to v2 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/9
 - chore(deps): update dependency typescript to v6 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/10

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "icon": "images/icon.png",
   "description": "Automatically removes unused #include directives in C/C++ files on save, using clangd diagnostics (requires llvm-vs-code-extensions.vscode-clangd).",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
This pull request is for the next release as v0.1.4 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.4 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.3" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* chore: add some badges by @michimani in https://github.com/michimani/vscode-clangd-include-cleaner/pull/19
* chore(deps): update node.js to v24.14.1 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/21
* chore(deps): update dependency @biomejs/biome to v2.4.9 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/22
* chore(deps): update dependency @biomejs/biome to v2.4.10 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/23
* chore(deps): update dependency @types/node to v24.12.2 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/24
* chore(deps): update songmu/tagpr digest to e7ae290 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/25
* chore(deps): update songmu/tagpr digest to 9d0f650 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/26
* chore(deps): update dependency @types/vscode to v1.115.0 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/27
* chore(deps): update dependency @biomejs/biome to v2.4.11 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/28
* chore(deps): update songmu/tagpr digest to 84850af by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/29
* chore(deps): update dependency @biomejs/biome to v2.4.12 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/30
* chore(deps): update dependency @types/vscode to v1.116.0 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/31
* chore(deps): update songmu/tagpr digest to 9bbb945 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/33
* chore(deps): update dependency typescript to v6.0.3 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/34
* chore(deps): update node.js to v24.15.0 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/32


**Full Changelog**: https://github.com/michimani/vscode-clangd-include-cleaner/compare/v0.1.3...tagpr-from-v0.1.3