### PR TITLE
Release for v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v0.1.6](https://github.com/michimani/vscode-clangd-include-cleaner/compare/v0.1.5...v0.1.6) - 2026-05-09
+- chore(deps): update dependency @types/vscode to v1.118.0 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/39
+- chore(deps): update dependency @biomejs/biome to v2.4.14 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/41
+- chore(deps): update dependency @types/node to v24.12.3 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/42
+- chore(deps): update songmu/tagpr digest to 555e72c by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/43
+- chore(deps): update dependency @biomejs/biome to v2.4.15 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/44
+
 ## [v0.1.5](https://github.com/michimani/vscode-clangd-include-cleaner/compare/v0.1.4...v0.1.5) - 2026-04-23
 - chore: replace VS Marketplace badges from shields to vsmarketplacebadges by @michimani in https://github.com/michimani/vscode-clangd-include-cleaner/pull/35
 - chore(deps): update actions/setup-node digest to 48b55a0 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/37

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "icon": "images/icon.png",
   "description": "Automatically removes unused #include directives in C/C++ files on save, using clangd diagnostics (requires llvm-vs-code-extensions.vscode-clangd).",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
This pull request is for the next release as v0.1.6 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.6 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.5" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* chore(deps): update dependency @types/vscode to v1.118.0 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/39
* chore(deps): update dependency @biomejs/biome to v2.4.14 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/41
* chore(deps): update dependency @types/node to v24.12.3 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/42
* chore(deps): update songmu/tagpr digest to 555e72c by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/43
* chore(deps): update dependency @biomejs/biome to v2.4.15 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/44


**Full Changelog**: https://github.com/michimani/vscode-clangd-include-cleaner/compare/v0.1.5...tagpr-from-v0.1.5