### PR TITLE
Release for v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v1.0.1](https://github.com/michimani/vscode-clangd-include-cleaner/compare/v1.0.0...v1.0.1) - 2026-06-04
+
+- chore(deps): update node.js to v24.16.0 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/49
+- chore(deps): update dependency @biomejs/biome to v2.4.16 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/51
+- chore(deps): update songmu/tagpr digest to e84001b by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/52
+- chore(deps): update actions/checkout digest to df4cb1c by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/53
+- chore(deps): update node.js to v24.13.0 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/54
+
 ## [v1.0.0](https://github.com/michimani/vscode-clangd-include-cleaner/compare/v0.1.6...v1.0.0) - 2026-05-15
 - chore(deps): update dependency @types/node to v24.12.4 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/45
 - chore(deps): update dependency @types/vscode to v1.120.0 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/47

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "icon": "images/icon.png",
   "description": "Automatically removes unused #include directives in C/C++ files on save, using clangd diagnostics (requires llvm-vs-code-extensions.vscode-clangd).",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
This pull request is for the next release as v1.0.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.0.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v1.0.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* chore(deps): update node.js to v24.16.0 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/49
* chore(deps): update dependency @biomejs/biome to v2.4.16 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/51
* chore(deps): update songmu/tagpr digest to e84001b by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/52
* chore(deps): update actions/checkout digest to df4cb1c by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/53
* chore(deps): update node.js to v24.13.0 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/54


**Full Changelog**: https://github.com/michimani/vscode-clangd-include-cleaner/compare/v1.0.0...tagpr-from-v1.0.0