### PR TITLE
Release for v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [v1.0.2](https://github.com/michimani/vscode-clangd-include-cleaner/compare/v1.0.1...v1.0.2) - 2026-06-20
+
+- chore(deps): update node.js to v24.13.1 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/55
+- chore(deps): update node.js to v24.13.2 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/57
+- chore(deps): update dependency @biomejs/biome to v2.5.0 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/58
+- chore(deps): update dependency @types/vscode to v1.125.0 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/59
+- chore(deps): update actions/checkout action to v7 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/61
+- chore(deps): update node.js to v24.17.0 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/60
+
 ## [v1.0.1](https://github.com/michimani/vscode-clangd-include-cleaner/compare/v1.0.0...v1.0.1) - 2026-06-04
 
 - chore(deps): update node.js to v24.16.0 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/49

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "icon": "images/icon.png",
   "description": "Automatically removes unused #include directives in C/C++ files on save, using clangd diagnostics (requires llvm-vs-code-extensions.vscode-clangd).",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
This pull request is for the next release as v1.0.2 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.0.2 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v1.0.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* chore(deps): update node.js to v24.13.1 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/55
* chore(deps): update node.js to v24.13.2 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/57
* chore(deps): update dependency @biomejs/biome to v2.5.0 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/58
* chore(deps): update dependency @types/vscode to v1.125.0 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/59
* chore(deps): update actions/checkout action to v7 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/61
* chore(deps): update node.js to v24.17.0 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/60


**Full Changelog**: https://github.com/michimani/vscode-clangd-include-cleaner/compare/v1.0.1...tagpr-from-v1.0.1