### PR TITLE
Release for v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v1.0.3](https://github.com/michimani/vscode-clangd-include-cleaner/compare/v1.0.2...v1.0.3) - 2026-07-05
+
+- chore(deps): update dependency @biomejs/biome to v2.5.1 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/62
+- chore(deps): update node.js by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/64
+- chore(deps): update dependency @biomejs/biome to v2.5.2 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/65
+- chore(deps): update mcr.microsoft.com/devcontainers/typescript-node docker tag to v5 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/66
+
 ## [v1.0.2](https://github.com/michimani/vscode-clangd-include-cleaner/compare/v1.0.1...v1.0.2) - 2026-06-20
 
 - chore(deps): update node.js to v24.13.1 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/55

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "icon": "images/icon.png",
   "description": "Automatically removes unused #include directives in C/C++ files on save, using clangd diagnostics (requires llvm-vs-code-extensions.vscode-clangd).",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
This pull request is for the next release as v1.0.3 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.0.3 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v1.0.2" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* chore(deps): update dependency @biomejs/biome to v2.5.1 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/62
* chore(deps): update node.js by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/64
* chore(deps): update dependency @biomejs/biome to v2.5.2 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/65
* chore(deps): update mcr.microsoft.com/devcontainers/typescript-node docker tag to v5 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/66


**Full Changelog**: https://github.com/michimani/vscode-clangd-include-cleaner/compare/v1.0.2...tagpr-from-v1.0.2