### PR TITLE
Release for v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [v1.0.4](https://github.com/michimani/vscode-clangd-include-cleaner/compare/v1.0.3...v1.0.4) - 2026-08-19
+
+- chore(deps): update dependency @biomejs/biome to v2.5.3 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/67
+- chore(deps): update dependency @types/node to v24.13.3 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/68
+- chore(deps): update songmu/tagpr digest to d1b8138 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/73
+- chore(deps): update actions/setup-node action to v7 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/72
+- chore(deps): update dependency typescript to v7 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/70
+- chore(deps): update dependency @biomejs/biome to v2.5.4 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/74
+- chore(deps): update dependency @biomejs/biome to v2.5.5 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/76
+- chore(deps): update actions/checkout digest to 3d3c42e by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/75
+- chore(deps): update dependency @biomejs/biome to v2.5.6 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/77
+- chore(deps): update node.js to v24.18.1 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/78
+- chore(deps): update dependency @biomejs/biome to v2.5.7 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/80
+- chore(deps): update node.js to v24.19.0 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/79
+- chore(deps): update dependency @biomejs/biome to v2.5.8 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/81
+- chore(deps): update dependency @biomejs/biome to v2.5.9 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/82
+- chore(deps): update dependency @types/vscode to v1.134.0 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/83
+
 ## [v1.0.3](https://github.com/michimani/vscode-clangd-include-cleaner/compare/v1.0.2...v1.0.3) - 2026-07-05
 
 - chore(deps): update dependency @biomejs/biome to v2.5.1 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/62

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "icon": "images/icon.png",
   "description": "Automatically removes unused #include directives in C/C++ files on save, using clangd diagnostics (requires llvm-vs-code-extensions.vscode-clangd).",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "engines": {
     "vscode": "^1.85.0"
   },


### PR DESCRIPTION
This pull request is for the next release as v1.0.4 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v1.0.4 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v1.0.3" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* chore(deps): update dependency @biomejs/biome to v2.5.3 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/67
* chore(deps): update dependency @types/node to v24.13.3 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/68
* chore(deps): update songmu/tagpr digest to d1b8138 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/73
* chore(deps): update actions/setup-node action to v7 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/72
* chore(deps): update dependency typescript to v7 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/70
* chore(deps): update dependency @biomejs/biome to v2.5.4 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/74
* chore(deps): update dependency @biomejs/biome to v2.5.5 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/76
* chore(deps): update actions/checkout digest to 3d3c42e by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/75
* chore(deps): update dependency @biomejs/biome to v2.5.6 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/77
* chore(deps): update node.js to v24.18.1 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/78
* chore(deps): update dependency @biomejs/biome to v2.5.7 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/80
* chore(deps): update node.js to v24.19.0 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/79
* chore(deps): update dependency @biomejs/biome to v2.5.8 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/81
* chore(deps): update dependency @biomejs/biome to v2.5.9 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/82
* chore(deps): update dependency @types/vscode to v1.134.0 by @renovate[bot] in https://github.com/michimani/vscode-clangd-include-cleaner/pull/83


**Full Changelog**: https://github.com/michimani/vscode-clangd-include-cleaner/compare/v1.0.3...tagpr-from-v1.0.3